### PR TITLE
allow passing CA file to request library

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ And if you have an onsite GitLab with HTTPS and self-signed certificates:
 
     NODE_TLS_REJECT_UNAUTHORIZED=0 gitlab-radiator
 
+You might prefer providing the CA file location in configuration instead of totally disabling TLS certificate checking.
+
 Then navigate with a browser to http://localhost:3000 - or whatever port you did configure.
 
 ## Configuration
@@ -57,6 +59,7 @@ Optional configuration properties:
 - ```intervals / builds``` -  Number of seconds between build state updates. Default value is 10 seconds.
 - ```port``` - HTTP port to listen on. Default value is 3000.
 - ```zoom``` - View zoom factor (to make your projects fit a display nicely). Default value is 1.0
+- ```caFile``` - CA file location to be passed to the request library when accessing your gitlab instance
 
 Example yaml syntax:
 

--- a/src/config.js
+++ b/src/config.js
@@ -12,6 +12,7 @@ config.interval.projects = Number(config.interval.projects || 120) * 1000
 config.interval.builds = Number(config.interval.builds || 10) * 1000
 config.port = Number(config.port || 3000)
 config.zoom = Number(config.zoom || 1.0)
+config.ca = config.caFile && fs.existsSync(config.caFile, 'utf-8') ? fs.readFileSync(config.caFile) : undefined
 
 function expandTilde(path) {
   return path.replace(/^~($|\/|\\)/, `${os.homedir()}$1`)

--- a/src/gitlab.js
+++ b/src/gitlab.js
@@ -64,7 +64,8 @@ function fetchBuildsForProject(project) {
 function fetch(path) {
   const options = {
     url: url.resolve(config.gitlab.url, path),
-    headers: {'PRIVATE-TOKEN': config.gitlab['access-token']}
+    headers: {'PRIVATE-TOKEN': config.gitlab['access-token']},
+    ca: config.ca
   }
 
   return Bacon.fromNodeCallback(callback => {


### PR DESCRIPTION
Allow passing, for example, the CA file used to sign the self signed certificate used for a Gitlab instance. Gitlab can then be used without disabling the security checks.