### PR TITLE
Implement config option for limiting stage jobs display

### DIFF
--- a/public/client.less
+++ b/public/client.less
@@ -133,14 +133,23 @@ ol.jobs {
   flex-direction: column;
 
   li {
-    padding: 6px;
-    color: @light-text-color;
-    border: 1px solid @background-color;
-    border-radius: 6px;
-    text-align: center;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
+    &:not(.hidden-jobs) {
+      padding: 6px;
+      color: @light-text-color;
+      border: 1px solid @background-color;
+      border-radius: 6px;
+      text-align: center;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+    }
+
+    &.hidden-jobs {
+      text-align: center;
+      color: @light-text-color;
+      font-size: 80%;
+      line-height: 100%;
+    }
 
     &:not(:last-child) {
       margin-bottom: 5px;

--- a/src/app.js
+++ b/src/app.js
@@ -31,7 +31,8 @@ const globalState = {
   error: null,
   zoom: config.zoom,
   projectsOrder: config.projectsOrder,
-  columns: config.columns
+  columns: config.columns,
+  maxNonFailedJobsVisible: config.maxNonFailedJobsVisible
 }
 
 socketIoServer.on('connection', (socket) => {

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -23,7 +23,8 @@ class RadiatorApp extends React.Component {
       {this.renderErrorMessage()}
       {this.renderProgressMessage()}
       <Projects now={this.state.now} zoom={this.state.zoom} columns={this.state.columns}
-                projects={this.state.projects || []} projectsOrder={this.state.projectsOrder}/>
+                projects={this.state.projects || []} projectsOrder={this.state.projectsOrder}
+                maxNonFailedJobsVisible={this.state.maxNonFailedJobsVisible} />
     </div>
 
   renderErrorMessage = () =>

--- a/src/client/jobs.js
+++ b/src/client/jobs.js
@@ -1,19 +1,58 @@
+import _ from 'lodash'
 import {Job} from './job'
 import PropTypes from 'prop-types'
 import React from 'react'
 
+const NON_BREAKING_SPACE = '\xa0'
+
+const JOB_STATES_IN_INTEREST_ORDER = [
+  'failed',
+  'running',
+  'created',
+  'pending',
+  'success',
+  'skipped'
+]
+
 export class Jobs extends React.PureComponent {
   render() {
-    const {jobs} = this.props
+    const {jobs, maxNonFailedJobsVisible} = this.props
+    function sortByOriginalOrder(jobArray) {
+      return _.orderBy(jobArray, job => jobs.indexOf(job))
+    }
+
+    const [failedJobs, nonFailedJobs] = _.partition(jobs, {status: 'failed'})
+    const filteredJobs = sortByOriginalOrder(
+      failedJobs.concat(
+        _.orderBy(nonFailedJobs, ({status}) => JOB_STATES_IN_INTEREST_ORDER.indexOf(status))
+          .slice(0, Math.max(0, maxNonFailedJobsVisible - failedJobs.length))
+      )
+    )
+
+    const hiddenJobs = jobs.filter(job => !filteredJobs.includes(job))
+    const hiddenCountsByStatus = _.mapValues(
+      _.groupBy(hiddenJobs, 'status'),
+      jobsForStatus => jobsForStatus.length
+      )
+    const hiddenJobsText =
+      _(hiddenCountsByStatus).toPairs()
+      .orderBy(([status]) => status)
+      .value()
+      .map(([status, count]) => `${count}${NON_BREAKING_SPACE}${status}`)
+      .join(', ')
 
     return <ol className="jobs">
-      {jobs.map((job, index) => {
+      {filteredJobs.map((job, index) => {
         return <Job job={job} key={index}/>
       })}
+      {
+        hiddenJobs.length > 0 ? <li className="hidden-jobs">+&nbsp;{hiddenJobsText}</li> : null
+      }
     </ol>
   }
 }
 
 Jobs.propTypes = {
-  jobs: PropTypes.array
+  jobs: PropTypes.array,
+  maxNonFailedJobsVisible: PropTypes.number
 }

--- a/src/client/project.js
+++ b/src/client/project.js
@@ -10,7 +10,7 @@ export class Project extends React.PureComponent {
 
     return <li className={`project ${project.status}`} style={this.style(columns)}>
       <h2>{project.name}</h2>
-      <Stages stages={pipeline.stages}/>
+      <Stages stages={pipeline.stages} maxNonFailedJobsVisible={this.props.maxNonFailedJobsVisible}/>
       <Info now={now} pipeline={pipeline}/>
     </li>
   }
@@ -26,5 +26,6 @@ export class Project extends React.PureComponent {
 Project.propTypes = {
   project: PropTypes.object,
   columns: PropTypes.number,
-  now: PropTypes.number
+  now: PropTypes.number,
+  maxNonFailedJobsVisible: PropTypes.number
 }

--- a/src/client/projects.js
+++ b/src/client/projects.js
@@ -10,7 +10,8 @@ export class Projects extends React.PureComponent {
     return <ol className="projects" style={this.zoomStyle(zoom)}>
       {_.sortBy(projects, projectsOrder)
         .map(project => {
-          return <Project now={now} columns={columns} project={project} key={project.id}/>
+          return <Project now={now} columns={columns} project={project} key={project.id}
+                          maxNonFailedJobsVisible={this.props.maxNonFailedJobsVisible}/>
         })
       }
     </ol>
@@ -30,5 +31,6 @@ Projects.propTypes = {
   projectsOrder: PropTypes.array,
   zoom: PropTypes.number,
   columns: PropTypes.number,
-  now: PropTypes.number
+  now: PropTypes.number,
+  maxNonFailedJobsVisible: PropTypes.number
 }

--- a/src/client/stage.js
+++ b/src/client/stage.js
@@ -8,11 +8,12 @@ export class Stage extends React.PureComponent {
 
     return <li className="stage">
       <div className="name">{stage.name}</div>
-      <Jobs jobs={stage.jobs}/>
+      <Jobs jobs={stage.jobs} maxNonFailedJobsVisible={this.props.maxNonFailedJobsVisible}/>
     </li>
   }
 }
 
 Stage.propTypes = {
-  stage: PropTypes.object
+  stage: PropTypes.object,
+  maxNonFailedJobsVisible: PropTypes.number
 }

--- a/src/client/stages.js
+++ b/src/client/stages.js
@@ -8,12 +8,13 @@ export class Stages extends React.PureComponent {
 
     return <ol className="stages">
       {stages.map((stage, index) => {
-        return <Stage stage={stage} key={index}/>
+        return <Stage stage={stage} key={index} maxNonFailedJobsVisible={this.props.maxNonFailedJobsVisible}/>
       })}
     </ol>
   }
 }
 
 Stages.propTypes = {
-  stages: PropTypes.array
+  stages: PropTypes.array,
+  maxNonFailedJobsVisible: PropTypes.number
 }

--- a/src/config.js
+++ b/src/config.js
@@ -12,6 +12,7 @@ config.port = Number(config.port || 3000)
 config.zoom = Number(config.zoom || 1.0)
 config.projectsOrder = (config.projects || {}).order || ['name']
 config.columns = Number(config.columns || 1)
+config.maxNonFailedJobsVisible = Number(config.maxNonFailedJobsVisible || 999999)
 config.ca = config.caFile && fs.existsSync(config.caFile, 'utf-8') ? fs.readFileSync(config.caFile) : undefined
 config.ignoreArchived = config.ignoreArchived === undefined ? true : config.ignoreArchived
 config.gitlab['access-token'] = config.gitlab['access-token'] || process.env.GITLAB_ACCESS_TOKEN


### PR DESCRIPTION
This commit introduces a config option for limiting the amount of jobs visible per stage. Jobs not visible get summarized by their status.

The logic is somewhat like this:
- failed jobs are always shown
- when deciding which jobs to show, prefer running over success and so on (see `JOB_STATES_IN_INTEREST_ORDER`)

Before:
<img width="563" alt="gitlab_build_radiator" src="https://user-images.githubusercontent.com/9249/53296162-81d07580-3812-11e9-952c-94d876f7d40b.png">

After:
<img width="456" alt="gitlab_build_radiator" src="https://user-images.githubusercontent.com/9249/53296159-606f8980-3812-11e9-98ef-eae484b7982f.png">
