### PR TITLE
Added config to exclude projects with specific pipeline statuses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Optional configuration properties:
 - ```projects / include``` - Regular expression for inclusion of projects. Default is to include all projects.
 - ```projects / exclude``` - Regular expression for exclusion of projects. Default is to exclude no projects.
 - ```projects / order``` - Array of projects attributes to use for sorting projects. Default value is ```['name']``` (available attributes are ```status, name, id, nameWithoutNamespace, group```).
+- ```projects / excludePipelineStatus``` - Array of pipeline statuses, that should be excluded (i.e. hidden) (available statuses are ```running, pending, success, failed, canceled, skipped```).
 - ```interval``` - Number of seconds between updateing projects and pipelines from GitLab. Default value is 10 seconds.
 - ```port``` - HTTP port to listen on. Default value is 3000.
 - ```zoom``` - View zoom factor (to make your projects fit a display nicely). Default value is 1.0
@@ -72,6 +73,7 @@ Example yaml syntax:
 projects:
   exclude: .*/.*-inactive-project
   order: ['status', 'name']
+  excludePipelineStatus: ['canceled', 'pending']
 auth:
   username: 'radiator'
   password: 'p455w0rd'

--- a/src/gitlab/index.js
+++ b/src/gitlab/index.js
@@ -8,6 +8,7 @@ export async function update(config) {
 
   return projectsWithPipelines
     .filter(project => project.pipelines.length > 0)
+    .filter(excludePipelineStatusFilter(config))
 }
 
 async function projectWithPipelines(project, config) {
@@ -31,3 +32,11 @@ function filterOutEmpty(pipelines) {
   return pipelines.filter(pipeline => pipeline.stages)
 }
 
+function excludePipelineStatusFilter(config) {
+  return project => {
+    if (config.projects && config.projects.excludePipelineStatus) {
+      return config.projects.excludePipelineStatus.includes(project.status)
+    }
+    return true
+  }
+}

--- a/test/gitlab-integration.js
+++ b/test/gitlab-integration.js
@@ -148,7 +148,7 @@ describe('Gitlab client', () => {
       [
         {
           archived: false,
-          group:  'gitlab-radiator-test',
+          group: 'gitlab-radiator-test',
           id: 5385889,
           name: 'gitlab-radiator-test/ci-skip-test-project',
           nameWithoutNamespace: 'ci-skip-test-project',
@@ -177,7 +177,7 @@ describe('Gitlab client', () => {
       },
       {
         archived: false,
-        group:  'gitlab-radiator-test',
+        group: 'gitlab-radiator-test',
         id: 5290928,
         name: 'gitlab-radiator-test/integration-test-project-2',
         nameWithoutNamespace: 'integration-test-project-2',
@@ -257,7 +257,7 @@ describe('Gitlab client', () => {
       },
       {
         archived: false,
-        group:  'gitlab-radiator-test',
+        group: 'gitlab-radiator-test',
         id: 5290865,
         name: 'gitlab-radiator-test/integration-test-project-1',
         nameWithoutNamespace: 'integration-test-project-1',


### PR DESCRIPTION
Thanks for merging my last two PR. This one seems to have a similar approach as pull request #36 from joux3. #36 limits jobs display and this one let's you set a config to filter e.g. all successful jobs.