### PR TITLE
Move socket.io to dependencies as it is needed on the server

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "esm": "3.2.6",
     "express": "4.16.4",
     "js-yaml": "3.12.1",
-    "lodash": "4.17.11"
+    "lodash": "4.17.11",
+    "socket.io": "2.2.0"
   },
   "devDependencies": {
     "@babel/cli": "7.2.3",
@@ -67,7 +68,6 @@
     "mocha": "6.0.1",
     "react": "16.8.3",
     "react-dom": "16.8.3",
-    "socket.io": "2.2.0",
     "uglify-js": "3.4.9"
   },
   "browserify": {


### PR DESCRIPTION
Starting a `gitlab-radiator` installed with npm fails as `socket.io` package will not be installed yet the server side code needs it.

Note: run `npm install` again before publishing this as I only changed `package.json`, not `package-lock.json`.