### PR TITLE
Added support for multi gitlabs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,48 +40,61 @@ It can be overridden by defining the ```GITLAB_RADIATOR_CONFIG``` environment va
 
 Mandatory configuration properties:
 
-- ```gitlab / url``` - Root URL of your GitLab installation - or that of GitLab SaaS CI
-- ```gitlab / access-token``` - A GitLab access token for allowing access to the GitLab API. One can be generated with GitLab's UI under Profile Settins / Personal Access Tokens. The value can alternatively be defined as `GITLAB_ACCESS_TOKEN` environment variable.
+- ```gitlabs / url``` - Root URL of your GitLab installation - or that of GitLab SaaS CI
+- ```gitlabs / access-token``` - A GitLab access token for allowing access to the GitLab API. One can be generated with GitLab's UI under Profile Settins / Personal Access Tokens. The value can alternatively be defined as `GITLAB_ACCESS_TOKEN` environment variable.
 
 Example yaml syntax:
 
 ```
-gitlab:
-  access-token: 12invalidtoken12
-  url: https://gitlab.com
+gitlabs:
+  -
+    access-token: 12invalidtoken12
+    url: https://gitlab.com
 ```
 
 Optional configuration properties:
 
-- ```projects / include``` - Regular expression for inclusion of projects. Default is to include all projects.
-- ```projects / exclude``` - Regular expression for exclusion of projects. Default is to exclude no projects.
-- ```projects / order``` - Array of projects attributes to use for sorting projects. Default value is ```['name']``` (available attributes are ```status, name, id, nameWithoutNamespace, group```).
-- ```projects / excludePipelineStatus``` - Array of pipeline statuses, that should be excluded (i.e. hidden) (available statuses are ```running, pending, success, failed, canceled, skipped```).
-- ```interval``` - Number of seconds between updateing projects and pipelines from GitLab. Default value is 10 seconds.
+- ```gitlabs / projects / include``` - Regular expression for inclusion of projects. Default is to include all projects.
+- ```gitlabs / projects / exclude``` - Regular expression for exclusion of projects. Default is to exclude no projects.
+- ```gitlabs / projects / excludePipelineStatus``` - Array of pipeline statuses, that should be excluded (i.e. hidden) (available statuses are ```running, pending, success, failed, canceled, skipped```).
+- ```gitlabs / projects / maxNonFailedJobsVisible``` - Number of non-failed jobs visible for a stage at maximum. Helps with highly concurrent project pipelines becoming uncomfortably high. Default values is unlimited.
+- ```gitlabs / auth / username``` - Enables HTTP basic authentication with the defined username and password.
+- ```gitlabs / auth / password``` - Enables HTTP basic authentication with the defined username and password.
+- ```gitlabs / caFile``` - CA file location to be passed to the request library when accessing the gitlab instance.
+- ```gitlabs / ignoreArchived``` - Ignore archived projects. Default value is `true`
+- ```projectsOrder``` - Array of project attributes to use for sorting projects. Default value is ```['name']``` (available attributes are ```status, name, id, nameWithoutNamespace, group```).
+- ```interval``` - Number of seconds between updateing projects and pipelines from GitLabs. Default value is 10 seconds.
 - ```port``` - HTTP port to listen on. Default value is 3000.
 - ```zoom``` - View zoom factor (to make your projects fit a display nicely). Default value is 1.0
 - ```columns``` - Number of columns to display (to fit more projects on screen). Default value is 1
-- ```caFile``` - CA file location to be passed to the request library when accessing your gitlab instance.
-- ```auth / username``` - Enables HTTP basic authentication with the defined username and password.
-- ```auth / password``` - Enables HTTP basic authentication with the defined username and password.
-- ```ignoreArchived``` - Ignore archived projects. Default value is `true`
-- ```maxNonFailedJobsVisible``` - Number of non-failed jobs visible for a stage at maximum. Helps with highly concurrent project pipelines becoming uncomfortably high. Default values is unlimited.
 
 Example yaml syntax:
 
 ```
-projects:
-  exclude: .*/.*-inactive-project
-  order: ['status', 'name']
-  excludePipelineStatus: ['canceled', 'pending']
-auth:
-  username: 'radiator'
-  password: 'p455w0rd'
+gitlabs:
+  -
+    access-token: 12invalidtoken12
+    url: https://gitlab.com
+    projects:
+      exclude: .*/.*-inactive-project
+      excludePipelineStatus: ['canceled', 'pending']
+      maxNonFailedJobsVisible: 3
+    auth:
+          username: 'radiator'
+      password: 'p455w0rd'
+projectsOrder: ['status', 'name']
 interval: 30
 port: 8000
 zoom: 0.85
 columns: 4
 ```
+
+## Breaking changes from 2.x to xx
+
+- Configuration file syntax has changed so that you now can define multiple gitlab instances to poll from. 
+E.g. polling from https://gitlab.com and from your own hosted https://gitlab.yourdomain.com instance of gitlab.
+Unfortunately all existing configurations for single gitlab polling have to be adjusted slightly.
+-  Also config param `order` has moved from `projects.order` to global `projectsOrder`, as the order has effect on all projects and not per gitlab config.
 
 ## Breaking changes from 1.x to 2.0
 

--- a/public/client.less
+++ b/public/client.less
@@ -27,6 +27,17 @@ h2 {
   color: @light-text-color;
 }
 
+h4 {
+  font-size: 24px;
+  font-weight: 400;
+  color: @light-text-color;
+}
+
+h6 {
+  font-size: 16px;
+  color: @light-text-color;
+}
+
 #app {
   position: fixed;
   width: 100%;
@@ -95,6 +106,17 @@ ol.projects {
       text-transform: uppercase;
       text-align: center;
       margin: 0 0 12px 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      line-height: 1.2em;
+    }
+
+    h4, h6 {
+      text-transform: lowercase;
+      text-align: center;
+      margin: 0;
+      padding: 0 0px 6px 0;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;

--- a/src/app.js
+++ b/src/app.js
@@ -31,8 +31,7 @@ const globalState = {
   error: null,
   zoom: config.zoom,
   projectsOrder: config.projectsOrder,
-  columns: config.columns,
-  maxNonFailedJobsVisible: config.maxNonFailedJobsVisible
+  columns: config.columns
 }
 
 socketIoServer.on('connection', (socket) => {

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -23,8 +23,7 @@ class RadiatorApp extends React.Component {
       {this.renderErrorMessage()}
       {this.renderProgressMessage()}
       <Projects now={this.state.now} zoom={this.state.zoom} columns={this.state.columns}
-                projects={this.state.projects || []} projectsOrder={this.state.projectsOrder}
-                maxNonFailedJobsVisible={this.state.maxNonFailedJobsVisible} />
+                projects={this.state.projects || []} projectsOrder={this.state.projectsOrder} />
     </div>
 
   renderErrorMessage = () =>

--- a/src/client/project.js
+++ b/src/client/project.js
@@ -10,7 +10,7 @@ export class Project extends React.PureComponent {
 
     return <li className={`project ${project.status}`} style={this.style(columns)}>
       <h2>{project.name}</h2>
-      <Stages stages={pipeline.stages} maxNonFailedJobsVisible={this.props.maxNonFailedJobsVisible}/>
+      <Stages stages={pipeline.stages} maxNonFailedJobsVisible={project.maxNonFailedJobsVisible}/>
       <Info now={now} pipeline={pipeline}/>
     </li>
   }

--- a/src/client/projects.js
+++ b/src/client/projects.js
@@ -10,8 +10,7 @@ export class Projects extends React.PureComponent {
     return <ol className="projects" style={this.zoomStyle(zoom)}>
       {_.sortBy(projects, projectsOrder)
         .map(project => {
-          return <Project now={now} columns={columns} project={project} key={project.id}
-                          maxNonFailedJobsVisible={this.props.maxNonFailedJobsVisible}/>
+          return <Project now={now} columns={columns} project={project} key={project.id}/>
         })
       }
     </ol>
@@ -31,6 +30,5 @@ Projects.propTypes = {
   projectsOrder: PropTypes.array,
   zoom: PropTypes.number,
   columns: PropTypes.number,
-  now: PropTypes.number,
-  maxNonFailedJobsVisible: PropTypes.number
+  now: PropTypes.number
 }

--- a/src/gitlab/pipelines.js
+++ b/src/gitlab/pipelines.js
@@ -1,11 +1,11 @@
 import _ from 'lodash'
 import {gitlabRequest} from './client'
 
-export async function fetchLatestPipelines(projectId, config) {
-  const pipelines = await fetchLatestAndMasterPipeline(projectId, config)
+export async function fetchLatestPipelines(projectId, gitlab) {
+  const pipelines = await fetchLatestAndMasterPipeline(projectId, gitlab)
 
   return Promise.all(pipelines.map(async ({id, ref, status}) => {
-    const jobs = await fetchJobs(projectId, id, config)
+    const jobs = await fetchJobs(projectId, id, gitlab)
     return {
       id,
       ref,

--- a/src/gitlab/projects.js
+++ b/src/gitlab/projects.js
@@ -1,22 +1,23 @@
 import _ from 'lodash'
 import {gitlabRequest} from './client'
 
-export async function fetchProjects(config) {
-  const projects = await fetchProjectsPaged(config)
+export async function fetchProjects(gitlab) {
+  const projects = await fetchProjectsPaged(gitlab)
   return _(projects)
     .flatten()
     .map(projectMapper)
-    .filter(regexFilter(config))
-    .filter(archivedFilter(config))
+    .filter(regexFilter(gitlab))
+    .filter(archivedFilter(gitlab))
     .value()
 }
 
-async function fetchProjectsPaged(config, page = 1, projectFragments = []) {
-  const {data, headers} = await gitlabRequest('/projects', {page, per_page: config.perPage || 100, membership: true}, config)
+async function fetchProjectsPaged(gitlab, page = 1, projectFragments = []) {
+  const {data, headers} = await gitlabRequest('/projects', {page, per_page: gitlab.perPage || 100, membership: true}, gitlab)
+
   projectFragments.push(data)
   const nextPage = headers['x-next-page']
   if (nextPage) {
-    return fetchProjectsPaged(config, Number(nextPage), projectFragments)
+    return fetchProjectsPaged(gitlab, Number(nextPage), projectFragments)
   }
   return projectFragments
 }

--- a/test/gitlab-integration.js
+++ b/test/gitlab-integration.js
@@ -10,7 +10,7 @@ const gitlab = {
 
 describe('Gitlab client', () => {
   it('Should find four projects with paging active and with no filtering ', async () => {
-    const config = {gitlab, perPage: 1}
+    const config = {...gitlab, perPage: 1}
     const projects = await fetchProjects(config)
     expect(projects).to.deep.equal([
       {archived: false, group: 'gitlab-radiator-test', id: 5385889, name: 'gitlab-radiator-test/ci-skip-test-project', nameWithoutNamespace: 'ci-skip-test-project'},
@@ -21,7 +21,7 @@ describe('Gitlab client', () => {
   })
 
   it('Should find one project with inclusive filtering', async () => {
-    const config = {gitlab, projects: {include: '.*project-1'}}
+    const config = {...gitlab, projects: {include: '.*project-1'}}
     const projects = await fetchProjects(config)
     expect(projects).to.deep.equal([
       {archived: false, id: 5290865, group: 'gitlab-radiator-test', name: 'gitlab-radiator-test/integration-test-project-1', nameWithoutNamespace: 'integration-test-project-1'}
@@ -29,7 +29,7 @@ describe('Gitlab client', () => {
   })
 
   it('Should find three projects with exclusive filtering', async () => {
-    const config = {gitlab, projects: {exclude: '.*project-1'}}
+    const config = {...gitlab, projects: {exclude: '.*project-1'}}
     const projects = await fetchProjects(config)
     expect(projects).to.deep.equal([
       {archived: false, id: 5385889, group: 'gitlab-radiator-test', name: 'gitlab-radiator-test/ci-skip-test-project', nameWithoutNamespace: 'ci-skip-test-project'},
@@ -39,7 +39,7 @@ describe('Gitlab client', () => {
   })
 
   it('Should find latest non-skipped pipeline for project', async () => {
-    const config = {gitlab}
+    const config = {...gitlab}
     const pipelines = await fetchLatestPipelines(5385889, config)
     expect(pipelines).to.deep.equal(
       [{
@@ -65,7 +65,7 @@ describe('Gitlab client', () => {
   })
 
   it('Should find latest pipelines for project (feature branch + master) with stages and retried jobs merged to one entry', async () => {
-    const config = {gitlab}
+    const config = {...gitlab}
     const pipelines = await fetchLatestPipelines(5290928, config)
     expect(pipelines).to.deep.equal(
       [{
@@ -142,7 +142,7 @@ describe('Gitlab client', () => {
   })
 
   it('Should find two projects with two pipelines for the first and one for the second (and exclude projects without pipelines)', async() => {
-    const config = {gitlab}
+    const config = {gitlabs: [{...gitlab}]}
     const projects = await update(config)
     expect(projects).to.deep.equal(
       [


### PR DESCRIPTION
Thanks again for accepting my PR. Here is the next one. This one introduces a breaking change to the config file. It allows you to define multiple gitlab instances to poll from.
E.g. polling from https://gitlab.com and from your own hosted https://gitlab.yourdomain.com instance of gitlab.
So, unfortunately all existing configurations for single gitlab polling have to be adjusted slightly.
I updated the readme accordingly.
I hope it is understandable and I hope you'll accept that PR. Thanks in advance and sorry to saddle you with work.