### PR TITLE
Group successfull projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,48 +40,61 @@ It can be overridden by defining the ```GITLAB_RADIATOR_CONFIG``` environment va
 
 Mandatory configuration properties:
 
-- ```gitlab / url``` - Root URL of your GitLab installation - or that of GitLab SaaS CI
-- ```gitlab / access-token``` - A GitLab access token for allowing access to the GitLab API. One can be generated with GitLab's UI under Profile Settins / Personal Access Tokens. The value can alternatively be defined as `GITLAB_ACCESS_TOKEN` environment variable.
+- ```gitlabs / url``` - Root URL of your GitLab installation - or that of GitLab SaaS CI
+- ```gitlabs / access-token``` - A GitLab access token for allowing access to the GitLab API. One can be generated with GitLab's UI under Profile Settins / Personal Access Tokens. The value can alternatively be defined as `GITLAB_ACCESS_TOKEN` environment variable.
 
 Example yaml syntax:
 
 ```
-gitlab:
-  access-token: 12invalidtoken12
-  url: https://gitlab.com
+gitlabs:
+  -
+    access-token: 12invalidtoken12
+    url: https://gitlab.com
 ```
 
 Optional configuration properties:
 
-- ```projects / include``` - Regular expression for inclusion of projects. Default is to include all projects.
-- ```projects / exclude``` - Regular expression for exclusion of projects. Default is to exclude no projects.
-- ```projects / order``` - Array of projects attributes to use for sorting projects. Default value is ```['name']``` (available attributes are ```status, name, id, nameWithoutNamespace, group```).
-- ```projects / excludePipelineStatus``` - Array of pipeline statuses, that should be excluded (i.e. hidden) (available statuses are ```running, pending, success, failed, canceled, skipped```).
-- ```interval``` - Number of seconds between updateing projects and pipelines from GitLab. Default value is 10 seconds.
+- ```gitlabs / projects / include``` - Regular expression for inclusion of projects. Default is to include all projects.
+- ```gitlabs / projects / exclude``` - Regular expression for exclusion of projects. Default is to exclude no projects.
+- ```gitlabs / projects / excludePipelineStatus``` - Array of pipeline statuses, that should be excluded (i.e. hidden) (available statuses are ```running, pending, success, failed, canceled, skipped```).
+- ```gitlabs / projects / maxNonFailedJobsVisible``` - Number of non-failed jobs visible for a stage at maximum. Helps with highly concurrent project pipelines becoming uncomfortably high. Default values is unlimited.
+- ```gitlabs / auth / username``` - Enables HTTP basic authentication with the defined username and password.
+- ```gitlabs / auth / password``` - Enables HTTP basic authentication with the defined username and password.
+- ```gitlabs / caFile``` - CA file location to be passed to the request library when accessing the gitlab instance.
+- ```gitlabs / ignoreArchived``` - Ignore archived projects. Default value is `true`
+- ```projectsOrder``` - Array of project attributes to use for sorting projects. Default value is ```['name']``` (available attributes are ```status, name, id, nameWithoutNamespace, group```).
+- ```interval``` - Number of seconds between updateing projects and pipelines from GitLabs. Default value is 10 seconds.
 - ```port``` - HTTP port to listen on. Default value is 3000.
 - ```zoom``` - View zoom factor (to make your projects fit a display nicely). Default value is 1.0
 - ```columns``` - Number of columns to display (to fit more projects on screen). Default value is 1
-- ```caFile``` - CA file location to be passed to the request library when accessing your gitlab instance.
-- ```auth / username``` - Enables HTTP basic authentication with the defined username and password.
-- ```auth / password``` - Enables HTTP basic authentication with the defined username and password.
-- ```ignoreArchived``` - Ignore archived projects. Default value is `true`
-- ```maxNonFailedJobsVisible``` - Number of non-failed jobs visible for a stage at maximum. Helps with highly concurrent project pipelines becoming uncomfortably high. Default values is unlimited.
 
 Example yaml syntax:
 
 ```
-projects:
-  exclude: .*/.*-inactive-project
-  order: ['status', 'name']
-  excludePipelineStatus: ['canceled', 'pending']
-auth:
-  username: 'radiator'
-  password: 'p455w0rd'
+gitlabs:
+  -
+    access-token: 12invalidtoken12
+    url: https://gitlab.com
+    projects:
+      exclude: .*/.*-inactive-project
+      excludePipelineStatus: ['canceled', 'pending']
+      maxNonFailedJobsVisible: 3
+    auth:
+          username: 'radiator'
+      password: 'p455w0rd'
+projectsOrder: ['status', 'name']
 interval: 30
 port: 8000
 zoom: 0.85
 columns: 4
 ```
+
+## Breaking changes from 2.x to xx
+
+- Configuration file syntax has changed so that you now can define multiple gitlab instances to poll from. 
+E.g. polling from https://gitlab.com and from your own hosted https://gitlab.yourdomain.com instance of gitlab.
+Unfortunately all existing configurations for single gitlab polling have to be adjusted slightly.
+-  Also config param `order` has moved from `projects.order` to global `projectsOrder`, as the order has effect on all projects and not per gitlab config.
 
 ## Breaking changes from 1.x to 2.0
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Optional configuration properties:
 - ```gitlabs / auth / password``` - Enables HTTP basic authentication with the defined username and password.
 - ```gitlabs / caFile``` - CA file location to be passed to the request library when accessing the gitlab instance.
 - ```gitlabs / ignoreArchived``` - Ignore archived projects. Default value is `true`
+- ```groupSuccessfulProjects``` - If set to `true` projects with successful pipeline status are grouped by namespace. Projects with other pipeline statuses are still rendered seperately. Default value is `false`.
 - ```projectsOrder``` - Array of project attributes to use for sorting projects. Default value is ```['name']``` (available attributes are ```status, name, id, nameWithoutNamespace, group```).
 - ```interval``` - Number of seconds between updateing projects and pipelines from GitLabs. Default value is 10 seconds.
 - ```port``` - HTTP port to listen on. Default value is 3000.

--- a/public/client.less
+++ b/public/client.less
@@ -80,6 +80,7 @@ ol.projects {
   flex-direction: row;
   flex-wrap: wrap;
   transform-origin: top left;
+
   li.project {
     margin: 12px;
     padding: 24px;
@@ -94,11 +95,11 @@ ol.projects {
 
     &.running {
       background: repeating-linear-gradient(
-        -45deg,
-        @project-background-color,
-        @project-background-color 20px,
-        darken(@project-background-color, 2%) 20px,
-        darken(@project-background-color, 2%) 40px
+              -45deg,
+              @project-background-color,
+              @project-background-color 20px,
+              darken(@project-background-color, 2%) 20px,
+              darken(@project-background-color, 2%) 40px
       );
     }
 
@@ -135,12 +136,14 @@ ol.stages {
     flex-direction: column;
     flex-grow: 1;
     min-width: 0;
+
     &:not(:last-child) {
       margin-right: 5px;
     }
+
     .name {
       font-size: 80%;
-      color:  @light-text-color;
+      color: @light-text-color;
       text-align: center;
       margin-bottom: 6px;
       text-overflow: ellipsis;
@@ -192,14 +195,66 @@ ol.jobs {
 
     &.running {
       background: repeating-linear-gradient(
-        -45deg,
-        @running-color,
-        @running-color 10px,
-        darken(@running-color, 8%) 10px,
-        darken(@running-color, 8%) 20px
+              -45deg,
+              @running-color,
+              @running-color 10px,
+              darken(@running-color, 8%) 10px,
+              darken(@running-color, 8%) 20px
       );
     }
   }
+}
+
+ol.groups {
+  list-style: none;
+  width: 100vmax;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  transform-origin: top left;
+
+  li.group {
+    margin: 12px;
+    padding: 24px;
+    border-radius: 6px;
+    background-color: @group-background-color;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .group-info {
+    padding: 6px;
+    color: @light-text-color;
+    border: 1px solid @background-color;
+    border-radius: 6px;
+    text-align: center;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    background-color: @success-color;
+  }
+
+  h2 {
+    text-transform: uppercase;
+    text-align: center;
+    margin: 0 0 12px 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    line-height: 1.2em;
+  }
+
+  h4, h6 {
+    text-transform: lowercase;
+    text-align: center;
+    margin: 0;
+    padding: 0 0px 6px 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    line-height: 1.2em;
+  }
+
 }
 
 .pipeline-info {
@@ -212,6 +267,7 @@ ol.jobs {
     display: flex;
     justify-content: space-between;
     min-width: 0;
+
     span {
       overflow: hidden;
       white-space: nowrap;

--- a/public/client.less
+++ b/public/client.less
@@ -27,6 +27,17 @@ h2 {
   color: @light-text-color;
 }
 
+h4 {
+  font-size: 24px;
+  font-weight: 400;
+  color: @light-text-color;
+}
+
+h6 {
+  font-size: 16px;
+  color: @light-text-color;
+}
+
 #app {
   position: fixed;
   width: 100%;
@@ -95,6 +106,17 @@ ol.projects {
       text-transform: uppercase;
       text-align: center;
       margin: 0 0 12px 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      line-height: 1.2em;
+    }
+
+    h4, h6 {
+      text-transform: lowercase;
+      text-align: center;
+      margin: 0;
+      padding: 0 0px 6px 0;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;

--- a/public/colors.less
+++ b/public/colors.less
@@ -5,6 +5,7 @@
 @light-text-color: rgb(215,215,217);
 @background-color: rgb(34,39,43);
 @project-background-color: rgb(53,58,62);
+@group-background-color: lighten(@project-background-color, 10%);
 
 @error-message-text-color: rgb(255,0,0);
 @error-message-background-color: rgb(139,0,0);

--- a/src/app.js
+++ b/src/app.js
@@ -31,8 +31,7 @@ const globalState = {
   error: null,
   zoom: config.zoom,
   projectsOrder: config.projectsOrder,
-  columns: config.columns,
-  maxNonFailedJobsVisible: config.maxNonFailedJobsVisible
+  columns: config.columns
 }
 
 socketIoServer.on('connection', (socket) => {

--- a/src/app.js
+++ b/src/app.js
@@ -31,7 +31,8 @@ const globalState = {
   error: null,
   zoom: config.zoom,
   projectsOrder: config.projectsOrder,
-  columns: config.columns
+  columns: config.columns,
+  groupSuccessfulProjects: config.groupSuccessfulProjects
 }
 
 socketIoServer.on('connection', (socket) => {

--- a/src/client/group.js
+++ b/src/client/group.js
@@ -1,0 +1,38 @@
+import {GroupInfo} from './groupInfo'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+export class Group extends React.PureComponent {
+  render() {
+    const {groupName, projects, now, columns} = this.props
+    const pipelines = []
+    projects.forEach((project) => {
+        project.pipelines.forEach((pipeline) => {
+          pipelines.push({
+            ...pipeline,
+            project: project.nameWithoutNamespace
+          })
+        })
+    })
+
+    return <li className={'group'} style={this.style(columns)}>
+      <h2>{groupName}</h2>
+      <div className={'group-info'}>{projects.length} Project{projects.length > 1 ? 's' : ''}</div>
+      <GroupInfo now={now} pipeline={pipelines[0]}/>
+    </li>
+  }
+
+  style = (columns) => {
+    const widthPercentage = Math.round(90 / columns)
+    return {
+      width: `${widthPercentage}%`
+    }
+  }
+}
+
+Group.propTypes = {
+  groupName: PropTypes.string,
+  projects: PropTypes.array,
+  now: PropTypes.number,
+  columns: PropTypes.number
+}

--- a/src/client/groupInfo.js
+++ b/src/client/groupInfo.js
@@ -2,14 +2,14 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import renderTimestamp from "./renderTimestamp"
 
-export class Info extends React.PureComponent {
+export class GroupInfo extends React.PureComponent {
   render() {
     const {pipeline, now} = this.props
 
     return <div className="pipeline-info">
       <div>
         <span>{pipeline.commit ? pipeline.commit.author : '-'}</span>
-        <span>{pipeline.commit ? `'${pipeline.commit.title}'` : '-'}</span>
+        <span>{pipeline.commit ? pipeline.project : '-'}</span>
       </div>
       <div>
         <span>{renderTimestamp(pipeline.stages, now)}</span>
@@ -19,7 +19,7 @@ export class Info extends React.PureComponent {
   }
 }
 
-Info.propTypes = {
+GroupInfo.propTypes = {
   pipeline: PropTypes.object,
   now: PropTypes.number
 }

--- a/src/client/groupedProjects.js
+++ b/src/client/groupedProjects.js
@@ -1,0 +1,64 @@
+import {Groups} from './groups'
+import {Projects} from './projects'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+export class GroupedProjects extends React.PureComponent {
+  render() {
+    const {projects, groupSuccessfulProjects} = this.props
+
+    if (groupSuccessfulProjects) {
+      return this.renderProjectsGrouped(projects)
+    }
+    return this.renderProjects(projects)
+  }
+
+  renderProjects(projects) {
+    const {zoom, columns, now, projectsOrder} = this.props
+    return <Projects now={now} zoom={zoom} columns={columns}
+                     projects={projects || []} projectsOrder={projectsOrder}/>
+  }
+
+  renderGroupedProjects(groupedProjects) {
+    const {zoom, columns, now} = this.props
+    return <Groups zoom={zoom} columns={columns} now={now}
+                     groupedProjects={groupedProjects || []} />
+  }
+
+  groupBy(items, key) {
+    return items.reduce(
+      (result, item) => ({
+        ...result,
+        [item[key]]: [
+          ...result[item[key]] || [],
+          item
+        ]
+      }), {})
+  }
+
+  renderProjectsGrouped(projects) {
+    const successfullProjects = []
+    const otherProjects = []
+    projects.forEach((project) => {
+      if (project.status === 'success') {
+        successfullProjects.push(project)
+      } else {
+        otherProjects.push(project)
+      }
+    })
+    const groupedProjects = this.groupBy(successfullProjects, 'group')
+    return <React.Fragment>
+      {this.renderProjects(otherProjects)}
+      {this.renderGroupedProjects(groupedProjects)}
+    </React.Fragment>
+  }
+}
+
+GroupedProjects.propTypes = {
+  projects: PropTypes.array,
+  projectsOrder: PropTypes.array,
+  zoom: PropTypes.number,
+  columns: PropTypes.number,
+  now: PropTypes.number,
+  groupSuccessfulProjects: PropTypes.bool
+}

--- a/src/client/groups.js
+++ b/src/client/groups.js
@@ -1,0 +1,34 @@
+import {Group} from './group'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+export class Groups extends React.PureComponent {
+  render() {
+    const {groupedProjects, now, zoom, columns} = this.props
+
+    return <ol className="groups" style={this.zoomStyle(zoom)}>
+      {Object.entries(groupedProjects)
+        .sort(([groupName1], [groupName2]) => {
+          return groupName1.localeCompare(groupName2)
+        })
+        .map(([groupName, projects]) => {
+          return <Group columns={columns} groupName={groupName} key={groupName} projects={projects} now={now}/>
+        })}
+    </ol>
+  }
+
+  zoomStyle = (zoom) => {
+    const widthPercentage = Math.round(100 / zoom)
+    return {
+      transform: `scale(${zoom})`,
+      width: `${widthPercentage}vmax`
+    }
+  }
+}
+
+Groups.propTypes = {
+  groupedProjects: PropTypes.object,
+  now: PropTypes.number,
+  zoom: PropTypes.number,
+  columns: PropTypes.number
+}

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,4 +1,4 @@
-import {Projects} from './projects'
+import {GroupedProjects} from './groupedProjects'
 import React from 'react'
 import ReactDOM from 'react-dom'
 
@@ -22,8 +22,10 @@ class RadiatorApp extends React.Component {
     <div>
       {this.renderErrorMessage()}
       {this.renderProgressMessage()}
-      <Projects now={this.state.now} zoom={this.state.zoom} columns={this.state.columns}
-                projects={this.state.projects || []} projectsOrder={this.state.projectsOrder} />
+
+      <GroupedProjects now={this.state.now} zoom={this.state.zoom} columns={this.state.columns}
+                       projects={this.state.projects || []} projectsOrder={this.state.projectsOrder}
+                       groupSuccessfulProjects={this.state.groupSuccessfulProjects}/>
     </div>
 
   renderErrorMessage = () =>

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -23,8 +23,7 @@ class RadiatorApp extends React.Component {
       {this.renderErrorMessage()}
       {this.renderProgressMessage()}
       <Projects now={this.state.now} zoom={this.state.zoom} columns={this.state.columns}
-                projects={this.state.projects || []} projectsOrder={this.state.projectsOrder}
-                maxNonFailedJobsVisible={this.state.maxNonFailedJobsVisible} />
+                projects={this.state.projects || []} projectsOrder={this.state.projectsOrder} />
     </div>
 
   renderErrorMessage = () =>

--- a/src/client/project.js
+++ b/src/client/project.js
@@ -10,7 +10,7 @@ export class Project extends React.PureComponent {
 
     return <li className={`project ${project.status}`} style={this.style(columns)}>
       <h2>{project.name}</h2>
-      <Stages stages={pipeline.stages} maxNonFailedJobsVisible={this.props.maxNonFailedJobsVisible}/>
+      <Stages stages={pipeline.stages} maxNonFailedJobsVisible={project.maxNonFailedJobsVisible}/>
       <Info now={now} pipeline={pipeline}/>
     </li>
   }

--- a/src/client/projects.js
+++ b/src/client/projects.js
@@ -10,8 +10,7 @@ export class Projects extends React.PureComponent {
     return <ol className="projects" style={this.zoomStyle(zoom)}>
       {_.sortBy(projects, projectsOrder)
         .map(project => {
-          return <Project now={now} columns={columns} project={project} key={project.id}
-                          maxNonFailedJobsVisible={this.props.maxNonFailedJobsVisible}/>
+          return <Project now={now} columns={columns} project={project} key={project.id}/>
         })
       }
     </ol>
@@ -31,6 +30,5 @@ Projects.propTypes = {
   projectsOrder: PropTypes.array,
   zoom: PropTypes.number,
   columns: PropTypes.number,
-  now: PropTypes.number,
-  maxNonFailedJobsVisible: PropTypes.number
+  now: PropTypes.number
 }

--- a/src/client/renderTimestamp.js
+++ b/src/client/renderTimestamp.js
@@ -1,0 +1,44 @@
+import _ from "lodash"
+import {distanceInWords} from "date-fns"
+
+export default function renderTimestamp(stages, now) {
+  const timestamps = getTimestamps(stages)
+
+  if (timestamps.length === 0) {
+    return 'Pending...'
+  }
+
+  const inProgress = _.some(timestamps, {finishedAt: undefined})
+  if (inProgress) {
+    const timestamp = _(timestamps).sortBy('startedAt').head()
+    return renderDistance('Started', timestamp.startedAt, now)
+  }
+
+  const timestamp = _(timestamps).sortBy('finishedAt').last()
+  return renderDistance('Finished', timestamp.finishedAt, now)
+}
+
+function getTimestamps(stages) {
+  return _(stages)
+    .map('jobs')
+    .flatten()
+    .map(job => {
+      const startedAt = job.startedAt && new Date(job.startedAt).valueOf()
+      const finishedAt = job.finishedAt && new Date(job.finishedAt).valueOf()
+      return {
+        startedAt,
+        finishedAt
+      }
+    })
+    .filter(timestamp => timestamp.startedAt)
+    .value()
+}
+
+function renderDistance(predicate, timestamp, now) {
+  const distance = formatDate(timestamp, now)
+  return `${predicate} ${distance} ago`
+}
+
+function formatDate(timestamp, now) {
+  return distanceInWords(new Date(timestamp), new Date(now))
+}

--- a/src/config.js
+++ b/src/config.js
@@ -11,6 +11,7 @@ config.interval = Number(config.interval || 10) * 1000
 config.port = Number(config.port || 3000)
 config.zoom = Number(config.zoom || 1.0)
 config.columns = Number(config.columns || 1)
+config.groupSuccessfulProjects = config.groupSuccessfulProjects || false
 config.projectsOrder = config.projectsOrder || ['name']
 config.gitlabs = config.gitlabs.map((gitlab) => {
   return {

--- a/src/gitlab/pipelines.js
+++ b/src/gitlab/pipelines.js
@@ -1,11 +1,11 @@
 import _ from 'lodash'
 import {gitlabRequest} from './client'
 
-export async function fetchLatestPipelines(projectId, config) {
-  const pipelines = await fetchLatestAndMasterPipeline(projectId, config)
+export async function fetchLatestPipelines(projectId, gitlab) {
+  const pipelines = await fetchLatestAndMasterPipeline(projectId, gitlab)
 
   return Promise.all(pipelines.map(async ({id, ref, status}) => {
-    const jobs = await fetchJobs(projectId, id, config)
+    const jobs = await fetchJobs(projectId, id, gitlab)
     return {
       id,
       ref,

--- a/src/gitlab/projects.js
+++ b/src/gitlab/projects.js
@@ -1,22 +1,23 @@
 import _ from 'lodash'
 import {gitlabRequest} from './client'
 
-export async function fetchProjects(config) {
-  const projects = await fetchProjectsPaged(config)
+export async function fetchProjects(gitlab) {
+  const projects = await fetchProjectsPaged(gitlab)
   return _(projects)
     .flatten()
     .map(projectMapper)
-    .filter(regexFilter(config))
-    .filter(archivedFilter(config))
+    .filter(regexFilter(gitlab))
+    .filter(archivedFilter(gitlab))
     .value()
 }
 
-async function fetchProjectsPaged(config, page = 1, projectFragments = []) {
-  const {data, headers} = await gitlabRequest('/projects', {page, per_page: config.perPage || 100, membership: true}, config)
+async function fetchProjectsPaged(gitlab, page = 1, projectFragments = []) {
+  const {data, headers} = await gitlabRequest('/projects', {page, per_page: gitlab.perPage || 100, membership: true}, gitlab)
+
   projectFragments.push(data)
   const nextPage = headers['x-next-page']
   if (nextPage) {
-    return fetchProjectsPaged(config, Number(nextPage), projectFragments)
+    return fetchProjectsPaged(gitlab, Number(nextPage), projectFragments)
   }
   return projectFragments
 }

--- a/test/gitlab-integration.js
+++ b/test/gitlab-integration.js
@@ -10,7 +10,7 @@ const gitlab = {
 
 describe('Gitlab client', () => {
   it('Should find four projects with paging active and with no filtering ', async () => {
-    const config = {gitlab, perPage: 1}
+    const config = {...gitlab, perPage: 1}
     const projects = await fetchProjects(config)
     expect(projects).to.deep.equal([
       {archived: false, group: 'gitlab-radiator-test', id: 5385889, name: 'gitlab-radiator-test/ci-skip-test-project', nameWithoutNamespace: 'ci-skip-test-project'},
@@ -21,7 +21,7 @@ describe('Gitlab client', () => {
   })
 
   it('Should find one project with inclusive filtering', async () => {
-    const config = {gitlab, projects: {include: '.*project-1'}}
+    const config = {...gitlab, projects: {include: '.*project-1'}}
     const projects = await fetchProjects(config)
     expect(projects).to.deep.equal([
       {archived: false, id: 5290865, group: 'gitlab-radiator-test', name: 'gitlab-radiator-test/integration-test-project-1', nameWithoutNamespace: 'integration-test-project-1'}
@@ -29,7 +29,7 @@ describe('Gitlab client', () => {
   })
 
   it('Should find three projects with exclusive filtering', async () => {
-    const config = {gitlab, projects: {exclude: '.*project-1'}}
+    const config = {...gitlab, projects: {exclude: '.*project-1'}}
     const projects = await fetchProjects(config)
     expect(projects).to.deep.equal([
       {archived: false, id: 5385889, group: 'gitlab-radiator-test', name: 'gitlab-radiator-test/ci-skip-test-project', nameWithoutNamespace: 'ci-skip-test-project'},
@@ -39,7 +39,7 @@ describe('Gitlab client', () => {
   })
 
   it('Should find latest non-skipped pipeline for project', async () => {
-    const config = {gitlab}
+    const config = {...gitlab}
     const pipelines = await fetchLatestPipelines(5385889, config)
     expect(pipelines).to.deep.equal(
       [{
@@ -65,7 +65,7 @@ describe('Gitlab client', () => {
   })
 
   it('Should find latest pipelines for project (feature branch + master) with stages and retried jobs merged to one entry', async () => {
-    const config = {gitlab}
+    const config = {...gitlab}
     const pipelines = await fetchLatestPipelines(5290928, config)
     expect(pipelines).to.deep.equal(
       [{
@@ -142,7 +142,7 @@ describe('Gitlab client', () => {
   })
 
   it('Should find two projects with two pipelines for the first and one for the second (and exclude projects without pipelines)', async() => {
-    const config = {gitlab}
+    const config = {gitlabs: [{...gitlab}]}
     const projects = await update(config)
     expect(projects).to.deep.equal(
       [


### PR DESCRIPTION
This one should only be merged after #41 as this one is built on top of that. Strictly speaking it's  seperate, but #41 introduces some breaking changes, so I thought I should move forward.
With this PR I introduce a possibility to group successful projects by group (aka namespace). This is useful, if you have a lot of projects but only a few groups. So you still see all your projects but you aren't bothered by to many information as long as the project pipelines ran successfully.