### PR TITLE
Added possibility to override default colors with values from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Optional configuration properties:
 - ```port``` - HTTP port to listen on. Default value is 3000.
 - ```zoom``` - View zoom factor (to make your projects fit a display nicely). Default value is 1.0
 - ```columns``` - Number of columns to display (to fit more projects on screen). Default value is 1
+- ```colors``` - Define some custom colors. Available colors `success, failed, running, light-text, background, project-background, group-background, error-message-text, error-message-background
+` (you may have a look at `/public/colors.less`, the colorNames from config will replace value for `@<colorname>-color` less variable)
 
 Example yaml syntax:
 
@@ -88,6 +90,8 @@ interval: 30
 port: 8000
 zoom: 0.85
 columns: 4
+colors:
+  success: 'rgb(0,255,0)'
 ```
 
 ## Changelog

--- a/src/app.js
+++ b/src/app.js
@@ -3,8 +3,13 @@ import compression from 'compression'
 import {config} from './config'
 import express from 'express'
 import http from 'http'
+import lessMiddleware from 'less-middleware'
+import os from 'os'
+import path from 'path'
 import socketIo from 'socket.io'
 import {update} from './gitlab'
+
+const cacheDir = path.join(os.tmpdir(), 'gitlab-radiator-css-cache')
 
 const app = express()
 const httpServer = http.Server(app)
@@ -17,9 +22,22 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 app.disable('x-powered-by')
+app.use(express.static(cacheDir))
+app.use(express.static(`${__dirname}/../public`))
+app.use(lessMiddleware(`${__dirname}/../public`, {
+    preprocess: {
+      less: (src) => {
+        let colorLess = ''
+        Object.keys(config.colors).forEach((stateName) => {
+          colorLess += '@' + stateName + '-color:' + config.colors[stateName] + ';'
+        })
+        return src + colorLess
+      }
+    }
+  }
+))
 app.use(compression())
 app.use(basicAuth(config.auth))
-app.use(express.static(`${__dirname}/../public`))
 
 httpServer.listen(config.port, () => {
   // eslint-disable-next-line no-console

--- a/src/config.js
+++ b/src/config.js
@@ -27,6 +27,7 @@ config.gitlabs = config.gitlabs.map((gitlab) => {
     }
   }
 })
+config.colors = config.colors || {}
 
 function expandTilde(path) {
   return path.replace(/^~($|\/|\\)/, `${os.homedir()}$1`)

--- a/src/dev-assets.js
+++ b/src/dev-assets.js
@@ -1,12 +1,6 @@
 import browserify from 'browserify-middleware'
-import express from 'express'
-import lessMiddleware from 'less-middleware'
-import os from 'os'
 import path from 'path'
 
 export function bindDevAssets(app) {
-  const cacheDir = path.join(os.tmpdir(), 'gitlab-radiator-css-cache')
-  app.use(lessMiddleware(`${__dirname}/../public`, {dest: cacheDir}))
-  app.use(express.static(cacheDir))
   app.get('/client.js', browserify(path.join(__dirname, '/client/index.js')))
 }


### PR DESCRIPTION
Moved less-middleware from dev-assets to app, added possibility to override default colors with values from config with less-middleware preprocessor.

You may want to first pull pull request #47 I have checked that and can confirm the bug and can also confirm the fix. The bug has been introduced by me on adding support for multiple gitlabs as that commit changed behaviour by copying values from file rather than just including it.