### PR TITLE
Add new less variables for other job status

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-```gitlab-radiator``` is a small Node.js application for serving a [Jenkins Radiator View](https://wiki.jenkins-ci.org/display/JENKINS/Radiator+View+Plugin) inspired web view of your team's CI pipelines fetched from a GitLab CI installation running locally or remotely.
+`gitlab-radiator` is a small Node.js application for serving a [Jenkins Radiator View](https://wiki.jenkins-ci.org/display/JENKINS/Radiator+View+Plugin) inspired web view of your team's CI pipelines fetched from a GitLab CI installation running locally or remotely.
 
 <img src="https://raw.github.com/heikkipora/gitlab-radiator/master/screenshot.png" width="50%">
 
@@ -35,13 +35,13 @@ Then navigate with a browser to http://localhost:3000 - or whatever port you did
 
 ## Configuration
 
-```gitlab-radiator``` looks for its mandatory configuration file at ```~/.gitlab-radiator.yml``` by default.
-It can be overridden by defining the ```GITLAB_RADIATOR_CONFIG``` environment variable.
+`gitlab-radiator` looks for its mandatory configuration file at `~/.gitlab-radiator.yml` by default.
+It can be overridden by defining the `GITLAB_RADIATOR_CONFIG` environment variable.
 
 Mandatory configuration properties:
 
-- ```gitlabs / url``` - Root URL of your GitLab installation - or that of GitLab SaaS CI
-- ```gitlabs / access-token``` - A GitLab access token for allowing access to the GitLab API. One can be generated with GitLab's UI under Profile Settins / Personal Access Tokens. The value can alternatively be defined as `GITLAB_ACCESS_TOKEN` environment variable.
+- `gitlabs / url` - Root URL of your GitLab installation - or that of GitLab SaaS CI
+- `gitlabs / access-token` - A GitLab access token for allowing access to the GitLab API. One can be generated with GitLab's UI under Profile Settins / Personal Access Tokens. The value can alternatively be defined as `GITLAB_ACCESS_TOKEN` environment variable.
 
 Example yaml syntax:
 
@@ -54,22 +54,21 @@ gitlabs:
 
 Optional configuration properties:
 
-- ```gitlabs / projects / include``` - Regular expression for inclusion of projects. Default is to include all projects.
-- ```gitlabs / projects / exclude``` - Regular expression for exclusion of projects. Default is to exclude no projects.
-- ```gitlabs / projects / excludePipelineStatus``` - Array of pipeline statuses, that should be excluded (i.e. hidden) (available statuses are ```running, pending, success, failed, canceled, skipped```).
-- ```gitlabs / maxNonFailedJobsVisible``` - Number of non-failed jobs visible for a stage at maximum. Helps with highly concurrent project pipelines becoming uncomfortably high. Default values is unlimited.
-- ```gitlabs / caFile``` - CA file location to be passed to the request library when accessing the gitlab instance.
-- ```gitlabs / ignoreArchived``` - Ignore archived projects. Default value is `true`
-- ```groupSuccessfulProjects``` - If set to `true` projects with successful pipeline status are grouped by namespace. Projects with other pipeline statuses are still rendered seperately. Default value is `false`.
-- ```auth / username``` - Enables HTTP basic authentication with the defined username and password.
-- ```auth / password``` - Enables HTTP basic authentication with the defined username and password.
-- ```projectsOrder``` - Array of project attributes to use for sorting projects. Default value is ```['name']``` (available attributes are ```status, name, id, nameWithoutNamespace, group```).
-- ```interval``` - Number of seconds between updateing projects and pipelines from GitLabs. Default value is 10 seconds.
-- ```port``` - HTTP port to listen on. Default value is 3000.
-- ```zoom``` - View zoom factor (to make your projects fit a display nicely). Default value is 1.0
-- ```columns``` - Number of columns to display (to fit more projects on screen). Default value is 1
-- ```colors``` - Define some custom colors. Available colors `success-text, success-background, failed-text, failed-background, running-text, running-background, light-text, dark-text, background, project-background, group-background, error-message-text, error-message-background
-` (you may have a look at `/public/colors.less`, the colorNames from config will replace value for `@<colorname>-color` less variable)
+- `gitlabs / projects / include` - Regular expression for inclusion of projects. Default is to include all projects.
+- `gitlabs / projects / exclude` - Regular expression for exclusion of projects. Default is to exclude no projects.
+- `gitlabs / projects / excludePipelineStatus` - Array of pipeline statuses, that should be excluded (i.e. hidden) (available statuses are `running, pending, success, failed, canceled, skipped`).
+- `gitlabs / maxNonFailedJobsVisible` - Number of non-failed jobs visible for a stage at maximum. Helps with highly concurrent project pipelines becoming uncomfortably high. Default values is unlimited.
+- `gitlabs / caFile` - CA file location to be passed to the request library when accessing the gitlab instance.
+- `gitlabs / ignoreArchived` - Ignore archived projects. Default value is `true`
+- `groupSuccessfulProjects` - If set to `true` projects with successful pipeline status are grouped by namespace. Projects with other pipeline statuses are still rendered seperately. Default value is `false`.
+- `auth / username` - Enables HTTP basic authentication with the defined username and password.
+- `auth / password` - Enables HTTP basic authentication with the defined username and password.
+- `projectsOrder` - Array of project attributes to use for sorting projects. Default value is `['name']` (available attributes are `status, name, id, nameWithoutNamespace, group`).
+- `interval` - Number of seconds between updateing projects and pipelines from GitLabs. Default value is 10 seconds.
+- `port` - HTTP port to listen on. Default value is 3000.
+- `zoom` - View zoom factor (to make your projects fit a display nicely). Default value is 1.0
+- `columns` - Number of columns to display (to fit more projects on screen). Default value is 1
+- `colors` - Define some custom colors. Available colors `success-text, success-background, failed-text, failed-background, running-text, running-background, pending-text, pending-background, skipped-text, skipped-background, created-text, created-background, light-text, dark-text, background, project-background, group-background, error-message-text, error-message-background` (you may have a look at `/public/colors.less`, the colorNames from config will replace value for `@<colorname>-color` less variable)
 
 Example yaml syntax:
 
@@ -100,16 +99,17 @@ See [releases](https://github.com/heikkipora/gitlab-radiator/releases).
 
 ## Breaking changes from 2.x to 3.0
 
-- Configuration file syntax has changed so that you now can define multiple gitlab instances to poll from. 
-E.g. polling from https://gitlab.com and from your own hosted https://gitlab.yourdomain.com instance of gitlab.
-Unfortunately all existing configurations for single gitlab polling have to be adjusted slightly.
--  Also config param `order` has moved from `projects.order` to global `projectsOrder`, as the order has effect on all projects and not per gitlab config.
+- Configuration file syntax has changed so that you now can define multiple gitlab instances to poll from.
+  E.g. polling from https://gitlab.com and from your own hosted https://gitlab.yourdomain.com instance of gitlab.
+  Unfortunately all existing configurations for single gitlab polling have to be adjusted slightly.
+- Also config param `order` has moved from `projects.order` to global `projectsOrder`, as the order has effect on all projects and not per gitlab config.
 
 ## Contributing
 
-Pull requests are welcome. Kindly check that your code passes ESLint checks by running ```npm run eslint``` first.
+Pull requests are welcome. Kindly check that your code passes ESLint checks by running `npm run eslint` first.
 Integration tests are (for now) skipped for pull request builds on Travis as they depend on a secret API token.
 
 ## Contributors
- - Antti Oittinen ([codegeneralist](https://github.com/codegeneralist))
- - Christian Wagner ([wagner-ch](https://github.com/wagner-ch/))
+
+- Antti Oittinen ([codegeneralist](https://github.com/codegeneralist))
+- Christian Wagner ([wagner-ch](https://github.com/wagner-ch/))

--- a/public/client.less
+++ b/public/client.less
@@ -9,8 +9,9 @@
   box-sizing: border-box;
 }
 
-html, body {
-  font-family: 'Open Sans', sans-serif;
+html,
+body {
+  font-family: "Open Sans", sans-serif;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
@@ -75,7 +76,8 @@ a {
   }
 }
 
-li, ol {
+li,
+ol {
   margin: 0;
   padding: 0;
   list-style-type: none;
@@ -102,11 +104,11 @@ ol.projects {
 
     &.running {
       background: repeating-linear-gradient(
-              -45deg,
-              @project-background-color,
-              @project-background-color 20px,
-              darken(@project-background-color, 2%) 20px,
-              darken(@project-background-color, 2%) 40px
+        -45deg,
+        @project-background-color,
+        @project-background-color 20px,
+        darken(@project-background-color, 2%) 20px,
+        darken(@project-background-color, 2%) 40px
       );
     }
 
@@ -120,7 +122,8 @@ ol.projects {
       line-height: 1.2em;
     }
 
-    h4, h6 {
+    h4,
+    h6 {
       text-transform: lowercase;
       text-align: center;
       margin: 0;
@@ -187,8 +190,19 @@ ol.jobs {
       margin-bottom: 5px;
     }
 
-    &.created, &.pending, &.skipped {
-      background-color: @project-background-color;
+    &.skipped {
+      color: @skipped-text-color;
+      background-color: @skipped-background-color;
+    }
+
+    &.created {
+      color: @created-text-color;
+      background-color: @created-background-color;
+    }
+
+    &.pending {
+      color: @pending-text-color;
+      background-color: @pending-background-color;
     }
 
     &.failed {
@@ -204,11 +218,11 @@ ol.jobs {
     &.running {
       color: @running-text-color;
       background: repeating-linear-gradient(
-              -45deg,
-              @running-background-color,
-              @running-background-color 10px,
-              darken(@running-background-color, 8%) 10px,
-              darken(@running-background-color, 8%) 20px
+        -45deg,
+        @running-background-color,
+        @running-background-color 10px,
+        darken(@running-background-color, 8%) 10px,
+        darken(@running-background-color, 8%) 20px
       );
     }
   }
@@ -253,7 +267,8 @@ ol.groups {
     line-height: 1.2em;
   }
 
-  h4, h6 {
+  h4,
+  h6 {
     text-transform: lowercase;
     text-align: center;
     margin: 0;
@@ -263,7 +278,6 @@ ol.groups {
     white-space: nowrap;
     line-height: 1.2em;
   }
-
 }
 
 .pipeline-info {

--- a/public/colors.less
+++ b/public/colors.less
@@ -1,15 +1,21 @@
-@background-color: rgb(34,39,43);
-@light-text-color: rgb(215,215,217);
+@background-color: rgb(34, 39, 43);
+@light-text-color: rgb(215, 215, 217);
 @dark-text-color: @background-color;
-@project-background-color: rgb(53,58,62);
+@project-background-color: rgb(53, 58, 62);
 @group-background-color: lighten(@project-background-color, 10%);
 
+@created-text-color: @light-text-color;
+@created-background-color: @project-background-color;
+@skipped-text-color: @light-text-color;
+@skipped-background-color: @project-background-color;
+@pending-text-color: @light-text-color;
+@pending-background-color: @project-background-color;
 @success-text-color: @light-text-color;
-@success-background-color: rgb(34,115,110);
+@success-background-color: rgb(34, 115, 110);
 @failed-text-color: @dark-text-color;
-@failed-background-color: rgb(204,208,0);
+@failed-background-color: rgb(204, 208, 0);
 @running-text-color: @light-text-color;
 @running-background-color: @success-background-color;
 
-@error-message-text-color: rgb(255,0,0);
-@error-message-background-color: rgb(139,0,0);
+@error-message-text-color: rgb(255, 0, 0);
+@error-message-background-color: rgb(139, 0, 0);


### PR DESCRIPTION
This adds the ability to easily customise the colors for other job statuses (pending, skipped, created).

Reason: For us having visibility of created jobs is valuable and the current default of the project background color makes it hard to separate out job state at a glance.

What changed: Simply addded some new less variables with defaults that match the current color scheme that allow overriding the backgorund and text color of jobs with status created, pending and skipped.