### PR TITLE
Config value commitAsTitle which changes title to commit message instead of project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Optional configuration properties:
 - `gitlabs / projects / excludePipelineStatus` - Array of pipeline statuses, that should be excluded (i.e. hidden) (available statuses are `running, pending, success, failed, canceled, skipped`).
 - `gitlabs / maxNonFailedJobsVisible` - Number of non-failed jobs visible for a stage at maximum. Helps with highly concurrent project pipelines becoming uncomfortably high. Default values is unlimited.
 - `gitlabs / branch` - Explicitly select the git branch to show pipelines for. Default value is empty, meaning pipelines for any branch are shown.
+- `gitlabs / commitAsTitle` - If set to `true` commit title used as block title instead of repository name. Default value is `false`.
 - `gitlabs / caFile` - CA file location to be passed to the request library when accessing the gitlab instance.
 - `gitlabs / ignoreArchived` - Ignore archived projects. Default value is `true`
 - `gitlabs / offlineRunners` - Report any offline CI runners. Set to `all` to include shared runners (requires administrator or auditor access), or `none` to ignore runner status completely. Set to `default` or leave out to report only on group / project runners available to the user.

--- a/public/client.less
+++ b/public/client.less
@@ -120,6 +120,10 @@ ol.projects {
       text-overflow: ellipsis;
       white-space: nowrap;
       line-height: 1.2em;
+
+      &.commit_title {
+        text-transform: none;
+      }
     }
 
     h4,

--- a/src/client/info.tsx
+++ b/src/client/info.tsx
@@ -2,11 +2,11 @@ import React from 'react'
 import {Timestamp} from './timestamp'
 import type {Pipeline} from '../common/gitlab-types'
 
-export function Info({pipeline, now}: {pipeline: Pipeline, now: number}) {
+export function Info({pipeline, now, commitAsTitle}: {pipeline: Pipeline, now: number, commitAsTitle: boolean}) {
   return <div className="pipeline-info">
     <div>
       <span>{pipeline.commit ? pipeline.commit.author : '-'}</span>
-      <span>{pipeline.commit ? `'${pipeline.commit.title}'` : '-'}</span>
+      <span>{commitAsTitle ? `Pipeline id: ${pipeline.id}` : (pipeline.commit ? `'${pipeline.commit.title}'` : '-')}</span>
     </div>
     <div>
       <Timestamp stages={pipeline.stages} now={now}/>

--- a/src/client/projects.tsx
+++ b/src/client/projects.tsx
@@ -45,13 +45,15 @@ function ProjectElement({columns, now, project, rotateRunningPipelines}: {column
   const indexLabel = isRotating ? `${pipelineIndex + 1}/${runningCount} `: ''
   const pipeline = project.pipelines[pipelineIndex]
 
+  const h2Class = project.commitAsTitle ? 'commit_title' : ''
+
   return <li className={`project ${project.status}`} style={style(columns)}>
-    <h2>
-      {project.url && <a href={`${project.url}/pipelines`} target="_blank" rel="noopener noreferrer">{indexLabel}{project.name}</a>}
+    <h2 className={`${h2Class}`}>
+      {project.url && <a href={`${project.url}/pipelines`} target="_blank" rel="noopener noreferrer">{indexLabel}{project.commitAsTitle ? (pipeline.commit ? pipeline.commit.title : '-') : project.name}</a>}
       {!project.url && project.name}
     </h2>
     <Stages stages={pipeline.stages} maxNonFailedJobsVisible={project.maxNonFailedJobsVisible}/>
-    <Info now={now} pipeline={pipeline}/>
+    <Info now={now} pipeline={pipeline} commitAsTitle={project.commitAsTitle}/>
   </li>
 }
 

--- a/src/common/gitlab-types.d.ts
+++ b/src/common/gitlab-types.d.ts
@@ -19,6 +19,7 @@ export interface Project {
   topics: string[]
   url: string
   default_branch: string
+  commitAsTitle: boolean
   pipelines: Pipeline[]
   maxNonFailedJobsVisible: number
   status: JobStatus

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,7 @@ const GitlabSchema = z.strictObject({
   branch: z.string().min(1).optional(),
   caFile: z.string().optional(),
   offlineRunners: z.literal(['all', 'default', 'none']).default('default'),
+  commitAsTitle: z.boolean().default(false),
   projects: z.strictObject({
     excludePipelineStatus: z.array(JobStatusSchema).optional(),
     include: z.string().min(1).optional(),
@@ -29,7 +30,7 @@ const GitlabSchema = z.strictObject({
     throw new Error('Mandatory gitlab access token missing from configuration (and none present at GITLAB_ACCESS_TOKEN env variable)')
   }
 
-  const {url, ignoreArchived, maxNonFailedJobsVisible, caFile, branch, offlineRunners, projects} = gitlab
+  const {url, ignoreArchived, maxNonFailedJobsVisible, caFile, branch, offlineRunners, commitAsTitle, projects} = gitlab
   const ca = caFile && fs.existsSync(caFile) ? fs.readFileSync(caFile, 'utf-8') : undefined
 
   return {
@@ -40,6 +41,7 @@ const GitlabSchema = z.strictObject({
     ca,
     offlineRunners,
     'access-token': accessToken,
+    commitAsTitle,
     projects
   }
 })

--- a/src/gitlab/index.ts
+++ b/src/gitlab/index.ts
@@ -33,6 +33,7 @@ async function projectWithPipelines(project: PartialProject, gitlab: Gitlab, pri
   return {
     ...project,
     maxNonFailedJobsVisible: gitlab.maxNonFailedJobsVisible,
+    commitAsTitle: gitlab.commitAsTitle,
     pipelines,
     status
   }

--- a/src/gitlab/projects.ts
+++ b/src/gitlab/projects.ts
@@ -2,7 +2,7 @@ import {gitlabRequest} from './client.ts'
 import type {Gitlab} from '../config.ts'
 import type {Project} from '../common/gitlab-types.d.ts'
 
-export type PartialProject = Omit<Project, 'pipelines' | 'maxNonFailedJobsVisible' | 'status'>
+export type PartialProject = Omit<Project, 'pipelines' | 'maxNonFailedJobsVisible' | 'commitAsTitle' | 'status'>
 
 interface GitlabProjectResponse {
   id: number

--- a/test/gitlab-integration.ts
+++ b/test/gitlab-integration.ts
@@ -11,6 +11,7 @@ const gitlab = {
   branch: undefined,
   ca: undefined,
   offlineRunners: 'none' as const,
+  commitAsTitle: false,
   projects: undefined
 }
 
@@ -164,6 +165,7 @@ describe('Gitlab client', () => {
           default_branch: 'master',
           group: 'gitlab-radiator-test',
           id: 5385889,
+          commitAsTitle: false,
           maxNonFailedJobsVisible: 10,
           name: 'gitlab-radiator-test/ci-skip-test-project',
           nameWithoutNamespace: 'ci-skip-test-project',
@@ -198,6 +200,7 @@ describe('Gitlab client', () => {
         default_branch: 'master',
         group: 'gitlab-radiator-test',
         id: 5290928,
+        commitAsTitle: false,
         maxNonFailedJobsVisible: 10,
         name: 'gitlab-radiator-test/integration-test-project-2',
         nameWithoutNamespace: 'integration-test-project-2',
@@ -286,6 +289,7 @@ describe('Gitlab client', () => {
         default_branch: 'master',
         group: 'gitlab-radiator-test',
         id: 5290865,
+        commitAsTitle: false,
         maxNonFailedJobsVisible: 10,
         name: 'gitlab-radiator-test/integration-test-project-1',
         nameWithoutNamespace: 'integration-test-project-1',


### PR DESCRIPTION
This changes title from repository name to job name. 

useful when showing only one repository.