### PR TITLE
Send unhandled errors and promise rejections from client to server and log them

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -42,6 +42,10 @@ const globalState: Omit<GlobalState, 'now'> = {
 
 socketIoServer.on('connection', (socket) => {
   socket.emit('state', withDate(globalState))
+
+  socket.on('browserError', (errorData) => {
+    console.error('Browser Error:', JSON.stringify(errorData, null, 2))
+  })
 })
 
 async function runUpdate() {

--- a/src/client/browser-error.ts
+++ b/src/client/browser-error.ts
@@ -1,0 +1,40 @@
+import type {BrowserError} from '../common/browser-error'
+import type {Socket} from 'socket.io-client'
+
+export function setupErrorLogger(socket: Socket) {
+  const errorHandler = (event: ErrorEvent) => socket.emit('browserError', fromErrorEvent(event))
+  const rejectionHandler = (event: PromiseRejectionEvent) => socket.emit('browserError', fromRejectionEvent(event))
+
+  window.addEventListener('error', errorHandler)
+  window.addEventListener('unhandledrejection', rejectionHandler)
+
+  return () => {
+    window.removeEventListener('error', errorHandler)
+    window.removeEventListener('unhandledrejection', rejectionHandler)
+  }
+}
+
+function fromErrorEvent(event: ErrorEvent): BrowserError {
+  return {
+    message: event.message,
+    stack: event.error?.stack,
+    timestamp: Date.now(),
+    url: window.location.href,
+    userAgent: navigator.userAgent,
+    type: 'error',
+    line: event.lineno,
+    column: event.colno,
+    source: event.filename
+  }
+}
+
+function fromRejectionEvent(event: PromiseRejectionEvent): BrowserError {
+  return {
+    message: event.reason?.message || String(event.reason),
+    stack: event.reason?.stack,
+    timestamp: Date.now(),
+    url: window.location.href,
+    userAgent: navigator.userAgent,
+    type: 'unhandledRejection'
+  }
+}

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -4,8 +4,9 @@ import 'regenerator-runtime/runtime'
 import {argumentsFromDocumentUrl} from './arguments'
 import {createRoot} from 'react-dom/client'
 import {GroupedProjects} from './groupedProjects'
-import React, {useCallback, useEffect, useMemo, useState} from 'react'
 import {io, Socket} from 'socket.io-client'
+import React, {useCallback, useEffect, useMemo, useState} from 'react'
+import {setupErrorLogger} from './browser-error'
 import type {GlobalState, Project} from '../common/gitlab-types'
 
 function RadiatorApp() {
@@ -37,10 +38,12 @@ function RadiatorApp() {
     const socket: Socket = io()
     socket.on('state', onServerStateUpdated)
     socket.on('disconnect', onDisconnect)
+    const unregisterLogger = setupErrorLogger(socket)
     return () => {
       socket.off('state', onServerStateUpdated)
       socket.off('disconnect', onDisconnect)
       socket.close()
+      unregisterLogger()
     }
   }, [onServerStateUpdated, onDisconnect])
 

--- a/src/common/browser-error.ts
+++ b/src/common/browser-error.ts
@@ -1,0 +1,11 @@
+export interface BrowserError {
+  message: string
+  stack?: string
+  timestamp: number
+  url: string
+  userAgent: string
+  type: 'error' | 'unhandledRejection'
+  line?: number
+  column?: number
+  source?: string
+}


### PR DESCRIPTION
This especially helps in diagnosing javascript compatibility issues with older smart TVs used as radiator displays (which do not have e.g. DevTools)

Example of an unhandled error being logged:
```
Browser Error: {
  "message": "Uncaught Error: includedTopics must be null or a non-empty array",
  "stack": "Error: includedTopics must be null or a non-empty array\n    at filterProjectsByTopics (http://localhost:3000/client.js:85625:11)\n    at RadiatorApp (http://localhost:3000/client.js:85594:26)\n    at Object.react_stack_bottom_frame (http://localhost:3000/client.js:77370:20)\n    at renderWithHooks (http://localhost:3000/client.js:59128:22)\n    at updateFunctionComponent (http://localhost:3000/client.js:61632:19)\n    at beginWork (http://localhost:3000/client.js:63244:18)\n    at runWithFiberInDEV (http://localhost:3000/client.js:52338:30)\n    at performUnitOfWork (http://localhost:3000/client.js:69107:22)\n    at workLoopSync (http://localhost:3000/client.js:68935:41)\n    at renderRootSync (http://localhost:3000/client.js:68916:11)",
  "timestamp": 1769248186653,
  "url": "http://localhost:3000/?topics=test",
  "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36",
  "type": "error",
  "line": 85625,
  "column": 11,
  "source": "http://localhost:3000/client.js"
}
```